### PR TITLE
[Onboarding practical example] Profile deletion status

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -3603,3 +3603,4 @@ newProfile:
     nameSurname: Name and Surname
     fiscalCode: Fiscal Code
     email: Email
+    delete: Delete profile

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -3603,3 +3603,4 @@ newProfile:
     nameSurname: Nome e Cognome
     fiscalCode: Codice Fiscale
     email: Indirizzo Email
+    delete: Cancella profilo

--- a/ts/features/profile/screens/ProfileNewMainScreen.tsx
+++ b/ts/features/profile/screens/ProfileNewMainScreen.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import { ScrollView } from "react-native";
 import { List } from "native-base";
 import * as pot from "@pagopa/ts-commons/lib/pot";
+import { ListItemSwitch } from "@pagopa/io-app-design-system";
 import { useIODispatch, useIOSelector } from "../../../store/hooks";
 import { IOStackNavigationRouteProps } from "../../../navigation/params/AppParamsList";
 import { MainTabParamsList } from "../../../navigation/params/MainTabParamsList";
@@ -11,6 +12,10 @@ import { selectProfileData } from "../../../features/profile/store/reducers";
 import { ErrorComponent } from "../components/Error";
 import { Loader } from "../components/Loader";
 import { ProfileData } from "../types";
+import I18n from "../../../i18n";
+import { loadUserDataProcessing } from "../../../store/actions/userDataProcessing";
+import { UserDataProcessingChoiceEnum } from "../../../../definitions/backend/UserDataProcessingChoice";
+import { userDataProcessingSelector } from "../../../store/reducers/userDataProcessing";
 import { config } from "./config";
 
 type Props = IOStackNavigationRouteProps<MainTabParamsList, "PROFILE_MAIN">;
@@ -18,9 +23,13 @@ type Props = IOStackNavigationRouteProps<MainTabParamsList, "PROFILE_MAIN">;
 const ProfileNewMainScreen: React.FC<Props> = () => {
   const dispatch = useIODispatch();
   const profile = useIOSelector(selectProfileData);
+  const userDataProcessing = useIOSelector(userDataProcessingSelector);
 
   useEffect(() => {
     dispatch(profileData.request());
+    dispatch(
+      loadUserDataProcessing.request(UserDataProcessingChoiceEnum.DELETE)
+    );
   }, [dispatch]);
 
   const renderProfileData = (profileData: ProfileData) => (
@@ -38,6 +47,10 @@ const ProfileNewMainScreen: React.FC<Props> = () => {
             iconName={iconName}
           />
         ))}
+        <ListItemSwitch
+          label={I18n.t("newProfile.labels.delete")}
+          isLoading={pot.isLoading(userDataProcessing.DELETE)}
+        />
       </List>
     </ScrollView>
   );


### PR DESCRIPTION
## Short description
This PR adds a switch that is active when the user has made a profile deletion request. The switch does not produce any effects.

## List of changes proposed in this pull request
- Switch linked to the profile deletion status

## How to test
Visit the profile tab.
